### PR TITLE
Add "linkTags" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ elem.innerHTML = prettyPrintJson.toHtml(data);
 | :---------- | :---------- | :------ | :-------------------------------- |
 | `indent`    | **integer** | `3`     | Number of spaces for indentation. |
 | `quoteKeys` | **boolean** | `false` | Always double quote key names.    |
+| `linkTags`  | **boolean** | `false` | Create anchor tags for links.     |
 
 <br>
 

--- a/pretty-print-json.js
+++ b/pretty-print-json.js
@@ -5,7 +5,7 @@ const prettyPrintJson = {
    version: '[VERSION]',
 
    toHtml(thing, options) {
-      const defaults = { indent: 3, quoteKeys: false };
+      const defaults = { indent: 3, quoteKeys: false, linkTags: false };
       const settings = { ...defaults, ...options };
       const htmlEntities = (string) => {
          // Makes text displayable in browsers
@@ -21,6 +21,14 @@ const prettyPrintJson = {
          const boolType = ['true', 'false'].includes(value) && 'boolean';
          const nullType = value === 'null' && 'null';
          const type =     boolType || nullType || strType || 'number';
+
+         if (settings.linkTags) {
+            const urlRegex = /https?:\/\/\S+\.[^\s"]+/gm;
+            const replaceLinks = (link) => '<a class=json-link href=' + link + '>' + link + '</a>';
+
+            value = value.replace(urlRegex, replaceLinks);
+         }
+
          return '<span class=json-' + type + '>' + value + '</span>';
          };
       const replacer = (match, p1, p2, p3, p4) => {

--- a/spec/interactive.html
+++ b/spec/interactive.html
@@ -109,7 +109,8 @@
          <i data-icon=copy data-click=app.copyToClipboard></i>
          <h3>Colorized output:</h3>
          <pre><output></output></pre>
-         <label><input type=checkbox data-change=app.processJson>quote map keys</label>
+         <label><input id="quoteKeys" type=checkbox data-change=app.processJson>quote map keys</label>
+         <label><input id="linkTags" type=checkbox data-change=app.processJson>create links</label>
       </div>
    </div>
 </main>
@@ -159,11 +160,15 @@
             textarea: component.find('textarea'),
             message:  component.find('#error-message').fadeOut(),
             output:   component.find('output'),
-            checkbox: component.find('input[type=checkbox]'),
+            quoteKeys: component.find('#quoteKeys'),
+            linkTags: component.find('#linkTags'),
             };
          try {
             const data = elem.textarea.val().trim().length ? JSON.parse(elem.textarea.val()) : null;
-            const options = { quoteKeys: elem.checkbox.is(':checked') };
+            const options = { 
+               quoteKeys: elem.quoteKeys.is(':checked'),
+               linkTags: elem.linkTags.is(':checked'),
+            };
             const html = data ? prettyPrintJson.toHtml(data, options) : '[EMPTY]';
             elem.output.html(html);
             }
@@ -188,6 +193,7 @@
             year:    new Date().getFullYear(),
             ios:     library.browser.iOS(),
             space:   '🪐🚀✨',
+            repo:    'https://github.com/center-key/pretty-print-json',
             };
          component.find('textarea').val(JSON.stringify(intro)).trigger('change');
          $('.version-number').text(prettyPrintJson.version);

--- a/spec/mocha.js
+++ b/spec/mocha.js
@@ -202,4 +202,23 @@ describe('The "indent" option', () => {
    });
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+describe('The "linkTags" option', () => {
+
+   it('creates anchor tags for urls', () => {
+      const input = { city: 'London', url: 'http://london.com/', info: 'Visit http://london.com/ for more info' };
+      const htmlLines = [
+         '{',
+         '   <span class=json-key>city</span>: <span class=json-string>"London"</span>,',
+         '   <span class=json-key>url</span>: <span class=json-string>"<a class=json-link href=http://london.com/>http://london.com/</a>"</span>,',
+         '   <span class=json-key>info</span>: <span class=json-string>"Visit <a class=json-link href=http://london.com/>http://london.com/</a> for more info"</span>',
+         '}'
+         ];
+      const actual =   { html: prettyPrintJson.toHtml(input, { linkTags: true }).split('\n') };
+      const expected = { html: htmlLines };
+      assert.deepStrictEqual(actual, expected);
+      });
+
+   });
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 });


### PR DESCRIPTION
I tried to implement the `linkTags` option discussed in #14.

Instead of checking if the field is a link i made it so that links can be detected even in the middle of a sentence.
I modified the regex to detect the links a bit so it would work better in this scenario where a link can be anywhere in a string.

I'm open to suggestions if there's anything that can be improved or simplified.

**Note:** For now I just included the changes in the "source" files, you'll still have to build the package, update the version, build the new site, etc.

Closes #14 