### PR TITLE
Option varstmt added to JSHint configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "unused": true,
       "browser": true,
       "node": true,
-      "mocha": true
+      "mocha": true,
+      "varstmt": true
    },
    "scripts": {
       "pretest": "jshint *.js spec && gulp build-dist",


### PR DESCRIPTION
Fixes #30.

Left behind the `docs/index.html` build because it converted all the `app` arrow functions to the more modern ES6 function definitions. I think it can be done in another PR!  :smile: 