### PR TITLE
Replace deprecated "./" folder mapping with subpath pattern "./*" in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
    "types": "dist/pretty-print-json.d.ts",
    "exports": {
       ".": "./dist/pretty-print-json.js",
-      "./": "./dist/"
+      "./*": "./dist/*"
    },
    "files": [
       "dist"


### PR DESCRIPTION
Recent Node.js versions (16+) deprecate the use of folder mappings like `"./": "./dist/"` in the "exports" field. This commit updates it to the recommended subpath pattern `./*: ./dist/*` to remove deprecation warnings and maintain compatibility with current and future Node.js releases.

The deprecation message looks like this:

```
[DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field
module resolution of the package at /.../node_modules/pretty-print-json/package.json.
Update this package.json to use a subpath pattern like "./*".
```